### PR TITLE
Enable editing transactions from table

### DIFF
--- a/src/components/EditDelete/index.js
+++ b/src/components/EditDelete/index.js
@@ -1,9 +1,8 @@
 import React, { useState } from "react";
 import "./styles.css";
 
-const EditEditDeleteModal = ({ transaction, onSave, onCancel, onDelete }) => {
+const EditTransactionModal = ({ transaction, onSave, onCancel, onDelete }) => {
   const [editedTransaction, setEditedTransaction] = useState(transaction);
-  console.log(editedTransaction);
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -12,15 +11,14 @@ const EditEditDeleteModal = ({ transaction, onSave, onCancel, onDelete }) => {
       [name]: value,
     }));
   };
-  console.log(editedTransaction);
 
   const handleSave = () => {
     onSave(editedTransaction);
   };
 
   const handleDelete = () => {
-    onDelete(editedTransaction)
-  }
+    onDelete(editedTransaction);
+  };
 
   return (
     <div className="modal container">
@@ -69,4 +67,4 @@ const EditEditDeleteModal = ({ transaction, onSave, onCancel, onDelete }) => {
   );
 };
 
-export default EditEditDeleteModal;
+export default EditTransactionModal;

--- a/src/components/TransactionsTable/index.js
+++ b/src/components/TransactionsTable/index.js
@@ -58,29 +58,32 @@ const TransactionsTable = ({ transactions, deleteTransaction, editTransaction })
             ? (record._pairDocIds?.[0] || record.id)
             : record.id
 
-        const items = [
-          {
+        const items = []
+
+        if (record.type !== 'transfer') {
+          items.push({
             key: 'edit',
             label: 'Редагувати',
             icon: <EditOutlined />,
             onClick: () => editTransaction?.(record),
-          },
-          {
-            key: 'delete',
-            label: (
-              <Popconfirm
-                title="Видалити?"
-                okText="Так"
-                cancelText="Ні"
-                onConfirm={() => deleteTransaction?.(docIdForDelete)}
-                onClick={(e) => e.stopPropagation()}
-              >
-                Видалити
-              </Popconfirm>
-            ),
-            icon: <DeleteOutlined style={{ color: 'red' }} />,
-          },
-        ]
+          })
+        }
+
+        items.push({
+          key: 'delete',
+          label: (
+            <Popconfirm
+              title="Видалити?"
+              okText="Так"
+              cancelText="Ні"
+              onConfirm={() => deleteTransaction?.(docIdForDelete)}
+              onClick={(e) => e.stopPropagation()}
+            >
+              Видалити
+            </Popconfirm>
+          ),
+          icon: <DeleteOutlined style={{ color: 'red' }} />,
+        })
 
         return (
           <Dropdown menu={{ items }} trigger={['click']} placement="bottomRight">

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react'
 import { DatePicker, Space, Checkbox } from 'antd'
 import TransactionsTable from '../components/TransactionsTable'
+import EditTransactionModal from '../components/EditDelete'
 import { useTransactions } from '../context/TransactionsContext'
 import { useDateRange } from '../context/DateRangeContext'
 
@@ -14,10 +15,23 @@ const normalizeToDate = (v) => {
 }
 
 const Dashboard = () => {
-  const { tableRows, transactions, deleteTransaction, editTransaction } = useTransactions()
+  const { tableRows, transactions, deleteTransaction, updateTransaction } = useTransactions()
   const { range, setRange, hasRange, startDate, endDate } = useDateRange()
 
   const [showTransfers, setShowTransfers] = useState(true)
+  const [editing, setEditing] = useState(null)
+
+  const startEdit = (t) => setEditing(t)
+  const cancelEdit = () => setEditing(null)
+  const handleSave = (t) => {
+    const { id, ...updates } = t
+    updateTransaction(id, updates)
+    setEditing(null)
+  }
+  const handleDelete = (t) => {
+    deleteTransaction(t.id)
+    setEditing(null)
+  }
 
   const data = useMemo(() => {
     const base = (tableRows?.length ? tableRows : transactions) || []
@@ -60,8 +74,16 @@ const Dashboard = () => {
       <TransactionsTable
         transactions={data}
         deleteTransaction={deleteTransaction}
-        editTransaction={editTransaction}
+        editTransaction={startEdit}
       />
+      {editing && (
+        <EditTransactionModal
+          transaction={editing}
+          onSave={handleSave}
+          onCancel={cancelEdit}
+          onDelete={handleDelete}
+        />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add modal for editing transactions and wire into dashboard
- hide edit action for transfers and call backend update

## Testing
- `CI=true npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68a31ffbd8fc832e959feeb79e5fd48d