### PR TITLE
Replace transaction type labels with icons

### DIFF
--- a/src/components/TransactionsTable/index.js
+++ b/src/components/TransactionsTable/index.js
@@ -1,6 +1,13 @@
 import './styles.css'
 import { Table, Popconfirm, Dropdown, Button } from 'antd'
-import { DeleteOutlined, EditOutlined, MoreOutlined } from '@ant-design/icons'
+import {
+  DeleteOutlined,
+  EditOutlined,
+  MoreOutlined,
+  ArrowUpOutlined,
+  ArrowDownOutlined,
+  SwapOutlined,
+} from '@ant-design/icons'
 import dayjs from 'dayjs'
 
 const normalizeToDate = (value) => {
@@ -46,6 +53,18 @@ const TransactionsTable = ({ transactions, deleteTransaction, editTransaction })
       title: 'Тип',
       dataIndex: 'type',
       key: 'type',
+      render: (type) => {
+        switch (type) {
+          case 'income':
+            return <ArrowUpOutlined style={{ color: 'green' }} />
+          case 'expense':
+            return <ArrowDownOutlined style={{ color: 'red' }} />
+          case 'transfer':
+            return <SwapOutlined style={{ color: 'black' }} />
+          default:
+            return type
+        }
+      },
     },
     { title: 'Назва', dataIndex: 'name', key: 'name' },
     { title: 'Коментарі', dataIndex: 'comments', key: 'comments' },


### PR DESCRIPTION
## Summary
- use ant-design icons for transaction types with red, green, and black colors

## Testing
- `CI=true npm test` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68a325d5d1e4832eb1f968d7d88ba7e6