### PR TITLE
Enable editing transactions using existing modals

### DIFF
--- a/src/components/TransactionsTable/index.js
+++ b/src/components/TransactionsTable/index.js
@@ -79,14 +79,12 @@ const TransactionsTable = ({ transactions, deleteTransaction, editTransaction })
 
         const items = []
 
-        if (record.type !== 'transfer') {
-          items.push({
-            key: 'edit',
-            label: 'Редагувати',
-            icon: <EditOutlined />,
-            onClick: () => editTransaction?.(record),
-          })
-        }
+        items.push({
+          key: 'edit',
+          label: 'Редагувати',
+          icon: <EditOutlined />,
+          onClick: () => editTransaction?.(record),
+        })
 
         items.push({
           key: 'delete',

--- a/src/components/forms/AddExpense.jsx
+++ b/src/components/forms/AddExpense.jsx
@@ -1,17 +1,39 @@
 import {Button, Modal, Form, Input, DatePicker} from 'antd'
-import {useState} from 'react'
+import {useState, useEffect} from 'react'
 import AccountSelect from './AccountSelect'
 import ExpenseCategorySelect from './ExpenseCategorySelect'
 import dayjs from 'dayjs'
 
-const AddExpense = ({isExpenseModalVisible, handleExpenseCancel, onFinish}) => {
+const AddExpense = ({
+  isExpenseModalVisible,
+  handleExpenseCancel,
+  onFinish,
+  initialValues,
+}) => {
   const [form] = Form.useForm()
   const [selectedCategory, setSelectedCategory] = useState(null)
+
+  useEffect(() => {
+    if (initialValues) {
+      setSelectedCategory(initialValues.name)
+      form.setFieldsValue({
+        amount: initialValues.amount,
+        account: initialValues.account,
+        date: initialValues.date ? dayjs(initialValues.date) : dayjs(),
+        comments: initialValues.comments,
+      })
+    } else {
+      form.resetFields()
+      setSelectedCategory(null)
+    }
+  }, [initialValues, form])
+
+  const isEdit = !!initialValues
 
   return (
     <Modal
       style={{fontWeight: 600}}
-      title='Додати витрати'
+      title={isEdit ? 'Редагувати витрату' : 'Додати витрати'}
       open={isExpenseModalVisible}
       onCancel={() => {
         handleExpenseCancel()
@@ -23,14 +45,14 @@ const AddExpense = ({isExpenseModalVisible, handleExpenseCancel, onFinish}) => {
       <Form
         form={form}
         layout='vertical'
-        onFinish={(values) => {
+        onFinish={async (values) => {
           if (!selectedCategory) {
             form.setFields([
               {name: 'category', errors: ['Виберіть або додайте категорію']},
             ])
             return
           }
-          onFinish({...values, category: selectedCategory}, 'expense')
+          await onFinish({...values, name: selectedCategory}, 'expense')
           form.resetFields()
           setSelectedCategory(null)
         }}
@@ -87,7 +109,7 @@ const AddExpense = ({isExpenseModalVisible, handleExpenseCancel, onFinish}) => {
 
         <Form.Item>
           <Button htmlType='submit' className='btn reset-balance-btn'>
-            Додати витрату
+            {isEdit ? 'Зберегти' : 'Додати витрату'}
           </Button>
         </Form.Item>
       </Form>

--- a/src/components/forms/AddIncome.jsx
+++ b/src/components/forms/AddIncome.jsx
@@ -1,14 +1,36 @@
 import {Button, Modal, Form, Input, DatePicker} from 'antd'
 import AccountSelect from './AccountSelect'
 import dayjs from 'dayjs'
+import {useEffect} from 'react'
 
-const AddIncome = ({isIncomeModalVisible, handleIncomeCancel, onFinish}) => {
+const AddIncome = ({
+  isIncomeModalVisible,
+  handleIncomeCancel,
+  onFinish,
+  initialValues,
+}) => {
   const [form] = Form.useForm()
+
+  useEffect(() => {
+    if (initialValues) {
+      form.setFieldsValue({
+        amount: initialValues.amount,
+        account: initialValues.account,
+        name: initialValues.name,
+        date: initialValues.date ? dayjs(initialValues.date) : dayjs(),
+        comments: initialValues.comments,
+      })
+    } else {
+      form.resetFields()
+    }
+  }, [initialValues, form])
+
+  const isEdit = !!initialValues
 
   return (
     <div>
       <Modal
-        title='Додати дохід'
+        title={isEdit ? 'Редагувати дохід' : 'Додати дохід'}
         open={isIncomeModalVisible}
         onCancel={handleIncomeCancel}
         footer={null}
@@ -16,8 +38,8 @@ const AddIncome = ({isIncomeModalVisible, handleIncomeCancel, onFinish}) => {
         <Form
           form={form}
           layout='vertical'
-          onFinish={(values) => {
-            onFinish(values, 'income')
+          onFinish={async (values) => {
+            await onFinish(values, 'income')
             form.resetFields()
           }}
         >
@@ -88,7 +110,7 @@ const AddIncome = ({isIncomeModalVisible, handleIncomeCancel, onFinish}) => {
 
           <Form.Item>
             <Button htmlType='submit' className='btn reset-balance-btn'>
-              Додати дохід
+              {isEdit ? 'Зберегти' : 'Додати дохід'}
             </Button>
           </Form.Item>
         </Form>

--- a/src/components/forms/AddTransfer.jsx
+++ b/src/components/forms/AddTransfer.jsx
@@ -1,13 +1,30 @@
 import {Modal, Form, InputNumber, Button, DatePicker} from 'antd'
 import dayjs from 'dayjs'
 import AccountSelect from './AccountSelect'
+import {useEffect} from 'react'
 
 const AddTransfer = ({
   isTransferModalVisible,
   handleTransferCancel,
   onTransfer,
+  initialValues,
 }) => {
   const [form] = Form.useForm()
+
+  useEffect(() => {
+    if (initialValues) {
+      form.setFieldsValue({
+        from: initialValues.from,
+        to: initialValues.to,
+        amount: initialValues.amount,
+        date: initialValues.date ? dayjs(initialValues.date) : dayjs(),
+      })
+    } else {
+      form.resetFields()
+    }
+  }, [initialValues, form])
+
+  const isEdit = !!initialValues
 
   const normalizeDate = (val) => {
     if (!val) return new Date()
@@ -17,21 +34,21 @@ const AddTransfer = ({
     return new Date(val)
   }
 
-  const onFinish = (values) => {
+  const onFinish = async (values) => {
     const payload = {
       from: values.from,
       to: values.to,
       amount: Number(values.amount),
       date: normalizeDate(values.date),
     }
-    onTransfer?.(payload) // далі у контексті робиш дві проводки з одним transferId
+    await onTransfer?.(payload) // далі у контексті робиш дві проводки з одним transferId
     form.resetFields()
     handleTransferCancel()
   }
 
   return (
     <Modal
-      title='Переказ між рахунками'
+      title={isEdit ? 'Редагувати переказ' : 'Переказ між рахунками'}
       open={isTransferModalVisible}
       onCancel={handleTransferCancel}
       footer={null}
@@ -109,7 +126,7 @@ const AddTransfer = ({
 
         <Form.Item>
           <Button type='primary' htmlType='submit' block>
-            Здійснити переказ
+            {isEdit ? 'Зберегти' : 'Здійснити переказ'}
           </Button>
         </Form.Item>
       </Form>


### PR DESCRIPTION
## Summary
- Allow AddIncome, AddExpense and AddTransfer modals to preload data and work for editing
- Hook Dashboard table edit actions into these modals and update transfers
- Add transfer update logic and expose edit action for all transaction types

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a335a10cf0832e95dd9b020b39f6d8