### PR TITLE
Add dividend and investment transaction types

### DIFF
--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -21,21 +21,27 @@ const Header = () => {
 
   const [income, setIncome] = useState(0)
   const [expense, setExpense] = useState(0)
+  const [dividend, setDividend] = useState(0)
+  const [investment, setInvestment] = useState(0)
   const [currentBalance, setCurrentBalance] = useState(0)
 
   useEffect(() => {
     let totalIncome = 0
     let totalExpense = 0
+    let totalDividend = 0
+    let totalInvestment = 0
 
     transactions.forEach((transaction) => {
-      if (transaction.type === 'income')
-        totalIncome += parseFloat(transaction.amount)
-      else if (transaction.type === 'expense')
-        totalExpense += parseFloat(transaction.amount)
+      if (transaction.type === 'income') totalIncome += parseFloat(transaction.amount)
+      else if (transaction.type === 'expense') totalExpense += parseFloat(transaction.amount)
+      else if (transaction.type === 'dividend') totalDividend += parseFloat(transaction.amount)
+      else if (transaction.type === 'investment') totalInvestment += parseFloat(transaction.amount)
     })
 
     setIncome(totalIncome)
     setExpense(totalExpense)
+    setDividend(totalDividend)
+    setInvestment(totalInvestment)
     setCurrentBalance(totalIncome - totalExpense)
   }, [transactions])
 
@@ -65,7 +71,10 @@ const Header = () => {
       <div className='navbar'>
         <HeaderWithAddButton />
         <div className='logo-wrap'>
-          <div>₴ {currentBalance} / ₴ {income} / ₴ -{expense}</div>
+          <div>
+            ₴ {currentBalance} / ₴ {income} / ₴ -{expense} / Дивіденди ₴ {dividend} /
+            Інвестиції ₴ {investment}
+          </div>
         </div>
 
         {/* Desktop menu */}

--- a/src/components/HeaderWithAddButton.js
+++ b/src/components/HeaderWithAddButton.js
@@ -6,6 +6,8 @@ import { toast } from 'react-toastify';
 import AddIncome from './forms/AddIncome';
 import AddExpense from './forms/AddExpense';
 import AddTransfer from './forms/AddTransfer';
+import AddDividend from './forms/AddDividend';
+import AddInvestment from './forms/AddInvestment';
 
 const normalizeToDate = (v) => {
   if (!v) return null;
@@ -20,14 +22,20 @@ const HeaderWithAddButton = () => {
   const [isExpenseModalVisible, setIsExpenseModalVisible] = useState(false);
   const [isIncomeModalVisible, setIsIncomeModalVisible] = useState(false);
   const [isTransferModalVisible, setIsTransferModalVisible] = useState(false);
+  const [isDividendModalVisible, setIsDividendModalVisible] = useState(false);
+  const [isInvestmentModalVisible, setIsInvestmentModalVisible] = useState(false);
 
   const showExpenseModal = () => setIsExpenseModalVisible(true);
   const showIncomeModal = () => setIsIncomeModalVisible(true);
   const showTransferModal = () => setIsTransferModalVisible(true);
+  const showDividendModal = () => setIsDividendModalVisible(true);
+  const showInvestmentModal = () => setIsInvestmentModalVisible(true);
 
   const handleExpenseCancel = () => setIsExpenseModalVisible(false);
   const handleIncomeCancel = () => setIsIncomeModalVisible(false);
   const handleTransferCancel = () => setIsTransferModalVisible(false);
+  const handleDividendCancel = () => setIsDividendModalVisible(false);
+  const handleInvestmentCancel = () => setIsInvestmentModalVisible(false);
 
   const onFinish = (values, type) => {
     const date = normalizeToDate(values.date);
@@ -48,6 +56,8 @@ const HeaderWithAddButton = () => {
     handleExpenseCancel();
     handleIncomeCancel();
     handleTransferCancel();
+    handleDividendCancel();
+    handleInvestmentCancel();
   };
 
   const handleTransfer = async ({ from, to, amount, date }) => {
@@ -65,6 +75,8 @@ const HeaderWithAddButton = () => {
     { key: 'income', label: 'Дохід', onClick: showIncomeModal },
     { key: 'expense', label: 'Витрати', onClick: showExpenseModal },
     { key: 'transfer', label: 'Переказ', onClick: showTransferModal },
+    { key: 'dividend', label: 'Дивіденд', onClick: showDividendModal },
+    { key: 'investment', label: 'Інвестиція', onClick: showInvestmentModal },
   ];
 
   return (
@@ -91,6 +103,16 @@ const HeaderWithAddButton = () => {
         isTransferModalVisible={isTransferModalVisible}
         handleTransferCancel={handleTransferCancel}
         onTransfer={handleTransfer}
+      />
+      <AddDividend
+        isDividendModalVisible={isDividendModalVisible}
+        handleDividendCancel={handleDividendCancel}
+        onFinish={onFinish}
+      />
+      <AddInvestment
+        isInvestmentModalVisible={isInvestmentModalVisible}
+        handleInvestmentCancel={handleInvestmentCancel}
+        onFinish={onFinish}
       />
     </>
   );

--- a/src/components/TransactionsTable/index.js
+++ b/src/components/TransactionsTable/index.js
@@ -7,6 +7,8 @@ import {
   ArrowUpOutlined,
   ArrowDownOutlined,
   SwapOutlined,
+  DollarCircleOutlined,
+  StockOutlined,
 } from '@ant-design/icons'
 import dayjs from 'dayjs'
 
@@ -61,6 +63,10 @@ const TransactionsTable = ({ transactions, deleteTransaction, editTransaction })
             return <ArrowDownOutlined style={{ color: 'red' }} />
           case 'transfer':
             return <SwapOutlined style={{ color: 'black' }} />
+          case 'dividend':
+            return <DollarCircleOutlined style={{ color: '#1890ff' }} />
+          case 'investment':
+            return <StockOutlined style={{ color: '#722ed1' }} />
           default:
             return type
         }
@@ -124,6 +130,8 @@ const TransactionsTable = ({ transactions, deleteTransaction, editTransaction })
             if (record.type === 'income') return 'row-income'
             if (record.type === 'expense') return 'row-expense'
             if (record.type === 'transfer') return 'row-transfer'
+            if (record.type === 'dividend') return 'row-dividend'
+            if (record.type === 'investment') return 'row-investment'
             return ''
           }}
         />

--- a/src/components/TransactionsTable/styles.css
+++ b/src/components/TransactionsTable/styles.css
@@ -121,3 +121,11 @@
 .row-expense {
   background-color: #fff1f0; /* світло-червоний */
 }
+
+.row-dividend {
+  background-color: #e6f7ff; /* світло-блакитний */
+}
+
+.row-investment {
+  background-color: #f9f0ff; /* світло-фіолетовий */
+}

--- a/src/components/forms/AddDividend.jsx
+++ b/src/components/forms/AddDividend.jsx
@@ -1,0 +1,102 @@
+import {Button, Modal, Form, Input, DatePicker} from 'antd'
+import AccountSelect from './AccountSelect'
+import dayjs from 'dayjs'
+import {useEffect} from 'react'
+
+const AddDividend = ({
+  isDividendModalVisible,
+  handleDividendCancel,
+  onFinish,
+  initialValues,
+}) => {
+  const [form] = Form.useForm()
+
+  useEffect(() => {
+    if (initialValues) {
+      form.setFieldsValue({
+        amount: initialValues.amount,
+        account: initialValues.account,
+        name: initialValues.name,
+        date: initialValues.date ? dayjs(initialValues.date) : dayjs(),
+        comments: initialValues.comments,
+      })
+    } else {
+      form.resetFields()
+    }
+  }, [initialValues, form])
+
+  const isEdit = !!initialValues
+
+  return (
+    <Modal
+      title={isEdit ? 'Редагувати дивіденд' : 'Додати дивіденд'}
+      open={isDividendModalVisible}
+      onCancel={handleDividendCancel}
+      footer={null}
+    >
+      <Form
+        form={form}
+        layout='vertical'
+        onFinish={async (values) => {
+          await onFinish(values, 'dividend')
+          form.resetFields()
+        }}
+      >
+        <Form.Item
+          style={{fontWeight: 600, maxWidth: '50%'}}
+          label='Сума'
+          name='amount'
+          rules={[{required: true, message: 'Вкажіть суму дивіденду'}]}
+        >
+          <Input type='number' inputMode='decimal' addonBefore='₴' />
+        </Form.Item>
+
+        <Form.Item
+          style={{fontWeight: 600}}
+          label='Рахунок'
+          name='account'
+          rules={[
+            {required: true, message: 'Вкажіть рахунок для транзакції'},
+          ]}
+        >
+          <AccountSelect />
+        </Form.Item>
+
+        <Form.Item
+          style={{fontWeight: 600}}
+          label='Назва'
+          name='name'
+          rules={[{required: true, message: 'Вкажіть назву транзакції'}]}
+        >
+          <Input type='text' />
+        </Form.Item>
+
+        <Form.Item
+          style={{fontWeight: 600}}
+          label='Дата'
+          name='date'
+          rules={[{required: true, message: 'Виберіть дату'}]}
+          initialValue={dayjs(new Date())}
+        >
+          <DatePicker />
+        </Form.Item>
+
+        <Form.Item
+          style={{fontWeight: 600}}
+          label='Коментар'
+          name='comments'
+        >
+          <Input type='text' />
+        </Form.Item>
+
+        <Form.Item>
+          <Button htmlType='submit' className='btn reset-balance-btn'>
+            {isEdit ? 'Зберегти' : 'Додати дивіденд'}
+          </Button>
+        </Form.Item>
+      </Form>
+    </Modal>
+  )
+}
+
+export default AddDividend

--- a/src/components/forms/AddInvestment.jsx
+++ b/src/components/forms/AddInvestment.jsx
@@ -1,0 +1,102 @@
+import {Button, Modal, Form, Input, DatePicker} from 'antd'
+import AccountSelect from './AccountSelect'
+import dayjs from 'dayjs'
+import {useEffect} from 'react'
+
+const AddInvestment = ({
+  isInvestmentModalVisible,
+  handleInvestmentCancel,
+  onFinish,
+  initialValues,
+}) => {
+  const [form] = Form.useForm()
+
+  useEffect(() => {
+    if (initialValues) {
+      form.setFieldsValue({
+        amount: initialValues.amount,
+        account: initialValues.account,
+        name: initialValues.name,
+        date: initialValues.date ? dayjs(initialValues.date) : dayjs(),
+        comments: initialValues.comments,
+      })
+    } else {
+      form.resetFields()
+    }
+  }, [initialValues, form])
+
+  const isEdit = !!initialValues
+
+  return (
+    <Modal
+      title={isEdit ? 'Редагувати інвестицію' : 'Додати інвестицію'}
+      open={isInvestmentModalVisible}
+      onCancel={handleInvestmentCancel}
+      footer={null}
+    >
+      <Form
+        form={form}
+        layout='vertical'
+        onFinish={async (values) => {
+          await onFinish(values, 'investment')
+          form.resetFields()
+        }}
+      >
+        <Form.Item
+          style={{fontWeight: 600, maxWidth: '50%'}}
+          label='Сума'
+          name='amount'
+          rules={[{required: true, message: 'Вкажіть суму інвестиції'}]}
+        >
+          <Input type='number' inputMode='decimal' addonBefore='₴' />
+        </Form.Item>
+
+        <Form.Item
+          style={{fontWeight: 600}}
+          label='Рахунок'
+          name='account'
+          rules={[
+            {required: true, message: "Вкажіть рахунок для транзакції"},
+          ]}
+        >
+          <AccountSelect />
+        </Form.Item>
+
+        <Form.Item
+          style={{fontWeight: 600}}
+          label='Назва'
+          name='name'
+          rules={[{required: true, message: 'Вкажіть назву транзакції'}]}
+        >
+          <Input type='text' />
+        </Form.Item>
+
+        <Form.Item
+          style={{fontWeight: 600}}
+          label='Дата'
+          name='date'
+          rules={[{required: true, message: 'Виберіть дату'}]}
+          initialValue={dayjs(new Date())}
+        >
+          <DatePicker />
+        </Form.Item>
+
+        <Form.Item
+          style={{fontWeight: 600}}
+          label='Коментар'
+          name='comments'
+        >
+          <Input type='text' />
+        </Form.Item>
+
+        <Form.Item>
+          <Button htmlType='submit' className='btn reset-balance-btn'>
+            {isEdit ? 'Зберегти' : 'Додати інвестицію'}
+          </Button>
+        </Form.Item>
+      </Form>
+    </Modal>
+  )
+}
+
+export default AddInvestment

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -4,6 +4,8 @@ import TransactionsTable from '../components/TransactionsTable'
 import AddIncome from '../components/forms/AddIncome'
 import AddExpense from '../components/forms/AddExpense'
 import AddTransfer from '../components/forms/AddTransfer'
+import AddDividend from '../components/forms/AddDividend'
+import AddInvestment from '../components/forms/AddInvestment'
 import { useTransactions } from '../context/TransactionsContext'
 import { useDateRange } from '../context/DateRangeContext'
 
@@ -115,6 +117,22 @@ const Dashboard = () => {
         <AddExpense
           isExpenseModalVisible
           handleExpenseCancel={cancelEdit}
+          onFinish={handleEditFinish}
+          initialValues={editing}
+        />
+      )}
+      {editing?.type === 'dividend' && (
+        <AddDividend
+          isDividendModalVisible
+          handleDividendCancel={cancelEdit}
+          onFinish={handleEditFinish}
+          initialValues={editing}
+        />
+      )}
+      {editing?.type === 'investment' && (
+        <AddInvestment
+          isInvestmentModalVisible
+          handleInvestmentCancel={cancelEdit}
           onFinish={handleEditFinish}
           initialValues={editing}
         />


### PR DESCRIPTION
## Summary
- add dividend and investment forms and modals
- show new transaction types in table with icons and colors
- include dividend and investment totals and editors in header and dashboard

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a33b687388832e8da9ef4ca789595b