### PR TITLE
Include dividends and investments in balance and show per-account balances

### DIFF
--- a/src/components/Header/styles.css
+++ b/src/components/Header/styles.css
@@ -34,3 +34,10 @@
   color: var(--white);
   cursor: pointer;
 }
+
+.account-balances {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
## Summary
- Include dividend and investment amounts in overall balance while keeping them out of income/expense totals
- Display each account's balance beneath the header for quick overview

## Testing
- `npx react-scripts test --watchAll=false` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a33f565cd4832eb907e207f819e4f6