### PR TITLE
Fix investment and dividend balance logic

### DIFF
--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -44,7 +44,7 @@ const Header = () => {
     setExpense(totalExpense)
     setDividend(totalDividend)
     setInvestment(totalInvestment)
-    setCurrentBalance(totalIncome - totalExpense + totalDividend - totalInvestment)
+    setCurrentBalance(totalIncome - totalExpense - totalDividend + totalInvestment)
   }, [transactions])
 
   const accountBalances = useMemo(() => {
@@ -52,9 +52,9 @@ const Header = () => {
     transactions.forEach((t) => {
       const amt = parseFloat(t.amount)
       if (!Number.isFinite(amt) || !t.account) return
-      if (t.type === 'income' || t.type === 'dividend')
+      if (t.type === 'income' || t.type === 'investment')
         balances[t.account] = (balances[t.account] || 0) + amt
-      else if (t.type === 'expense' || t.type === 'investment')
+      else if (t.type === 'expense' || t.type === 'dividend')
         balances[t.account] = (balances[t.account] || 0) - amt
     })
     return balances
@@ -95,7 +95,7 @@ const Header = () => {
         <HeaderWithAddButton />
         <div className='logo-wrap'>
           <div>
-            ₴ {currentBalance} / ₴ {income} / ₴ -{expense} / Дивіденди ₴ {dividend} /
+            ₴ {currentBalance} / ₴ {income} / ₴ -{expense} / Дивіденди ₴ -{dividend} /
             Інвестиції ₴ {investment}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Treat dividends as deductions and investments as additions when computing balances
- Show dividends as negative amounts in the header

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a3414b3e98832e9daeeb7f2a527aee