### PR TITLE
Add time selection and fix transaction date parsing

### DIFF
--- a/src/components/forms/AddDividend.jsx
+++ b/src/components/forms/AddDividend.jsx
@@ -3,6 +3,11 @@ import AccountSelect from './AccountSelect'
 import dayjs from 'dayjs'
 import {useEffect} from 'react'
 
+const toDayjs = (value) => {
+  if (!value) return dayjs()
+  return typeof value?.toDate === 'function' ? dayjs(value.toDate()) : dayjs(value)
+}
+
 const AddDividend = ({
   isDividendModalVisible,
   handleDividendCancel,
@@ -17,13 +22,14 @@ const AddDividend = ({
         amount: initialValues.amount,
         account: initialValues.account,
         name: initialValues.name,
-        date: initialValues.date ? dayjs(initialValues.date) : dayjs(),
+        date: toDayjs(initialValues.date),
         comments: initialValues.comments,
       })
-    } else {
+    } else if (isDividendModalVisible) {
       form.resetFields()
+      form.setFieldsValue({date: dayjs()})
     }
-  }, [initialValues, form])
+  }, [initialValues, isDividendModalVisible, form])
 
   const isEdit = !!initialValues
 
@@ -40,6 +46,7 @@ const AddDividend = ({
         onFinish={async (values) => {
           await onFinish(values, 'dividend')
           form.resetFields()
+          form.setFieldsValue({date: dayjs()})
         }}
       >
         <Form.Item
@@ -76,9 +83,12 @@ const AddDividend = ({
           label='Дата'
           name='date'
           rules={[{required: true, message: 'Виберіть дату'}]}
-          initialValue={dayjs(new Date())}
         >
-          <DatePicker />
+          <DatePicker
+            showTime
+            format='DD.MM.YYYY HH:mm'
+            style={{width: '100%'}}
+          />
         </Form.Item>
 
         <Form.Item

--- a/src/components/forms/AddExpense.jsx
+++ b/src/components/forms/AddExpense.jsx
@@ -4,6 +4,11 @@ import AccountSelect from './AccountSelect'
 import ExpenseCategorySelect from './ExpenseCategorySelect'
 import dayjs from 'dayjs'
 
+const toDayjs = (value) => {
+  if (!value) return dayjs()
+  return typeof value?.toDate === 'function' ? dayjs(value.toDate()) : dayjs(value)
+}
+
 const AddExpense = ({
   isExpenseModalVisible,
   handleExpenseCancel,
@@ -19,14 +24,15 @@ const AddExpense = ({
       form.setFieldsValue({
         amount: initialValues.amount,
         account: initialValues.account,
-        date: initialValues.date ? dayjs(initialValues.date) : dayjs(),
+        date: toDayjs(initialValues.date),
         comments: initialValues.comments,
       })
-    } else {
+    } else if (isExpenseModalVisible) {
       form.resetFields()
+      form.setFieldsValue({date: dayjs()})
       setSelectedCategory(null)
     }
-  }, [initialValues, form])
+  }, [initialValues, isExpenseModalVisible, form])
 
   const isEdit = !!initialValues
 
@@ -54,6 +60,7 @@ const AddExpense = ({
           }
           await onFinish({...values, name: selectedCategory}, 'expense')
           form.resetFields()
+          form.setFieldsValue({date: dayjs()})
           setSelectedCategory(null)
         }}
       >
@@ -98,9 +105,12 @@ const AddExpense = ({
           label='Дата'
           name='date'
           rules={[{required: true, message: 'Please select the expense date'}]}
-          initialValue={dayjs(new Date())}
         >
-          <DatePicker />
+          <DatePicker
+            showTime
+            format='DD.MM.YYYY HH:mm'
+            style={{width: '100%'}}
+          />
         </Form.Item>
 
         <Form.Item style={{fontWeight: 600}} label='Коментар' name='comments'>

--- a/src/components/forms/AddIncome.jsx
+++ b/src/components/forms/AddIncome.jsx
@@ -3,6 +3,11 @@ import AccountSelect from './AccountSelect'
 import dayjs from 'dayjs'
 import {useEffect} from 'react'
 
+const toDayjs = (value) => {
+  if (!value) return dayjs()
+  return typeof value?.toDate === 'function' ? dayjs(value.toDate()) : dayjs(value)
+}
+
 const AddIncome = ({
   isIncomeModalVisible,
   handleIncomeCancel,
@@ -17,13 +22,14 @@ const AddIncome = ({
         amount: initialValues.amount,
         account: initialValues.account,
         name: initialValues.name,
-        date: initialValues.date ? dayjs(initialValues.date) : dayjs(),
+        date: toDayjs(initialValues.date),
         comments: initialValues.comments,
       })
-    } else {
+    } else if (isIncomeModalVisible) {
       form.resetFields()
+      form.setFieldsValue({date: dayjs()})
     }
-  }, [initialValues, form])
+  }, [initialValues, isIncomeModalVisible, form])
 
   const isEdit = !!initialValues
 
@@ -41,6 +47,7 @@ const AddIncome = ({
           onFinish={async (values) => {
             await onFinish(values, 'income')
             form.resetFields()
+            form.setFieldsValue({date: dayjs()})
           }}
         >
           <Form.Item
@@ -89,9 +96,12 @@ const AddIncome = ({
             rules={[
               {required: true, message: 'Please select the income date!'},
             ]}
-            initialValue={dayjs(new Date())}
           >
-            <DatePicker />
+            <DatePicker
+              showTime
+              format='DD.MM.YYYY HH:mm'
+              style={{width: '100%'}}
+            />
           </Form.Item>
 
           <Form.Item

--- a/src/components/forms/AddInvestment.jsx
+++ b/src/components/forms/AddInvestment.jsx
@@ -3,6 +3,11 @@ import AccountSelect from './AccountSelect'
 import dayjs from 'dayjs'
 import {useEffect} from 'react'
 
+const toDayjs = (value) => {
+  if (!value) return dayjs()
+  return typeof value?.toDate === 'function' ? dayjs(value.toDate()) : dayjs(value)
+}
+
 const AddInvestment = ({
   isInvestmentModalVisible,
   handleInvestmentCancel,
@@ -17,13 +22,14 @@ const AddInvestment = ({
         amount: initialValues.amount,
         account: initialValues.account,
         name: initialValues.name,
-        date: initialValues.date ? dayjs(initialValues.date) : dayjs(),
+        date: toDayjs(initialValues.date),
         comments: initialValues.comments,
       })
-    } else {
+    } else if (isInvestmentModalVisible) {
       form.resetFields()
+      form.setFieldsValue({date: dayjs()})
     }
-  }, [initialValues, form])
+  }, [initialValues, isInvestmentModalVisible, form])
 
   const isEdit = !!initialValues
 
@@ -40,6 +46,7 @@ const AddInvestment = ({
         onFinish={async (values) => {
           await onFinish(values, 'investment')
           form.resetFields()
+          form.setFieldsValue({date: dayjs()})
         }}
       >
         <Form.Item
@@ -76,9 +83,12 @@ const AddInvestment = ({
           label='Дата'
           name='date'
           rules={[{required: true, message: 'Виберіть дату'}]}
-          initialValue={dayjs(new Date())}
         >
-          <DatePicker />
+          <DatePicker
+            showTime
+            format='DD.MM.YYYY HH:mm'
+            style={{width: '100%'}}
+          />
         </Form.Item>
 
         <Form.Item

--- a/src/components/forms/AddTransfer.jsx
+++ b/src/components/forms/AddTransfer.jsx
@@ -3,6 +3,11 @@ import dayjs from 'dayjs'
 import AccountSelect from './AccountSelect'
 import {useEffect} from 'react'
 
+const toDayjs = (value) => {
+  if (!value) return dayjs()
+  return typeof value?.toDate === 'function' ? dayjs(value.toDate()) : dayjs(value)
+}
+
 const AddTransfer = ({
   isTransferModalVisible,
   handleTransferCancel,
@@ -17,12 +22,13 @@ const AddTransfer = ({
         from: initialValues.from,
         to: initialValues.to,
         amount: initialValues.amount,
-        date: initialValues.date ? dayjs(initialValues.date) : dayjs(),
+        date: toDayjs(initialValues.date),
       })
-    } else {
+    } else if (isTransferModalVisible) {
       form.resetFields()
+      form.setFieldsValue({date: dayjs()})
     }
-  }, [initialValues, form])
+  }, [initialValues, isTransferModalVisible, form])
 
   const isEdit = !!initialValues
 
@@ -43,6 +49,7 @@ const AddTransfer = ({
     }
     await onTransfer?.(payload) // далі у контексті робиш дві проводки з одним transferId
     form.resetFields()
+    form.setFieldsValue({date: dayjs()})
     handleTransferCancel()
   }
 
@@ -57,7 +64,6 @@ const AddTransfer = ({
         form={form}
         layout='vertical'
         onFinish={onFinish}
-        initialValues={{date: dayjs()}}
       >
         <Form.Item
           label='Сума'
@@ -121,7 +127,11 @@ const AddTransfer = ({
           name='date'
           rules={[{required: true, message: 'Оберіть дату'}]}
         >
-          <DatePicker style={{width: '100%'}} />
+          <DatePicker
+            showTime
+            format='DD.MM.YYYY HH:mm'
+            style={{width: '100%'}}
+          />
         </Form.Item>
 
         <Form.Item>


### PR DESCRIPTION
## Summary
- add conversion helpers to handle Firestore timestamps
- default new transactions to current date and time
- allow choosing date and time in all transaction forms

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a386ea8ba4832e96f2cc9945d101b6