### PR TITLE
feat: persist filters in local storage

### DIFF
--- a/src/context/DateRangeContext.js
+++ b/src/context/DateRangeContext.js
@@ -1,11 +1,35 @@
-import {createContext, useContext, useState, useMemo} from 'react'
+import {createContext, useContext, useState, useMemo, useEffect} from 'react'
+import dayjs from 'dayjs'
 
 const DateRangeContext = createContext(null)
 export const useDateRange = () => useContext(DateRangeContext)
 
 /** Зберігаємо dayjs об’єкти: [start, end] або [] */
 export const DateRangeProvider = ({children}) => {
-  const [range, setRange] = useState([]) // [dayjs(), dayjs()] | []
+  const [range, setRange] = useState(() => {
+    try {
+      const raw = localStorage.getItem('dateRange')
+      if (!raw) return []
+      const parsed = JSON.parse(raw)
+      if (Array.isArray(parsed) && parsed[0] && parsed[1]) {
+        return [dayjs(parsed[0]), dayjs(parsed[1])]
+      }
+    } catch (e) {
+      // ignore
+    }
+    return []
+  }) // [dayjs(), dayjs()] | []
+
+  useEffect(() => {
+    if (Array.isArray(range) && range[0] && range[1]) {
+      localStorage.setItem(
+        'dateRange',
+        JSON.stringify(range.map((d) => d?.toISOString?.()))
+      )
+    } else {
+      localStorage.removeItem('dateRange')
+    }
+  }, [range])
 
   const value = useMemo(
     () => ({


### PR DESCRIPTION
## Summary
- persist date range selection in local storage
- add transaction type filters and remove separate transfer toggle

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a390d21ed4832e9df2909c73deba39