### PR TITLE
feat: show planned and actual financial model

### DIFF
--- a/src/pages/BusinessModel.js
+++ b/src/pages/BusinessModel.js
@@ -1,16 +1,21 @@
 import { Table } from 'antd';
 import { useTransactions } from '../context/TransactionsContext';
-import { useExpenseCategories } from '../context/ExpenseCategoriesContext';
 
-const plannedPercents = {
-  Хозка: 2,
-  Закупка: 35,
-  Маркетинг: 2,
-};
+// Планові відсотки згідно фінансової моделі
+const planItems = [
+  { group: 'Змінні витрати', name: 'Food cost', category: 'Закупка', planned: '25-30' },
+  { group: 'Фіксовані витрати', name: 'Зарплати персоналу', category: 'Зарплати персоналу', planned: '20-25' },
+  { group: 'Фіксовані витрати', name: 'Оренда', category: 'Оренда', planned: '8-10' },
+  { group: 'Фіксовані витрати', name: 'Комунальні', category: 'Комунальні', planned: '5-7' },
+  { group: 'Фіксовані витрати', name: 'Податки', category: 'Податки', planned: '3-5' },
+  { group: 'Фіксовані витрати', name: 'Маркетинг', category: 'Маркетинг', planned: '3-5' },
+  { group: 'Фіксовані витрати', name: 'Операційні витрати', category: 'Операційні витрати', planned: '2-3' },
+  { group: 'Фіксовані витрати', name: 'Господарка (хозка)', category: 'Хозка', planned: '2-3' },
+  { group: 'Фіксовані витрати', name: 'Інші витрати', category: 'Інші витрати', planned: '2-3' },
+];
 
 const BusinessModel = () => {
   const { transactions } = useTransactions();
-  const { expenseCategories } = useExpenseCategories();
 
   const totalTurnover = transactions
     .filter(t => t.type === 'income')
@@ -21,27 +26,47 @@ const BusinessModel = () => {
       .filter(t => t.type === 'expense' && t.category === categoryName)
       .reduce((sum, t) => sum + Math.abs(Number(t.amount || 0)), 0);
 
-  const data = expenseCategories.map(cat => {
-    const plannedPercent = plannedPercents[cat.name] || 0;
-    const plannedAmount = (plannedPercent / 100) * totalTurnover;
-    const actualAmount = getActualSum(cat.name);
+  const data = planItems.map((item, idx) => {
+    const actualAmount = getActualSum(item.category);
+    const actualPercent = totalTurnover ? (actualAmount / totalTurnover) * 100 : 0;
     return {
-      key: cat.id,
-      name: cat.name,
-      plannedPercent: `${plannedPercent}%`,
-      plannedAmount: plannedAmount.toFixed(2),
+      key: idx,
+      group: item.group,
+      name: item.name,
+      plannedPercent: item.planned,
+      actualPercent: actualPercent.toFixed(2),
       actualAmount: actualAmount.toFixed(2),
-      diff: (plannedAmount - actualAmount).toFixed(2),
     };
   });
 
+  const totalExpenses = transactions
+    .filter(t => t.type === 'expense')
+    .reduce((sum, t) => sum + Math.abs(Number(t.amount || 0)), 0);
+  const expensePercent = totalTurnover ? (totalExpenses / totalTurnover) * 100 : 0;
+  const profitAmount = totalTurnover - totalExpenses;
+  const profitPercent = 100 - expensePercent;
+
   const columns = [
     { title: 'Категорія', dataIndex: 'name', key: 'name' },
-    { title: '% від обороту', dataIndex: 'plannedPercent', key: 'plannedPercent' },
-    { title: 'Запланована сума', dataIndex: 'plannedAmount', key: 'plannedAmount' },
-    { title: 'Фактична сума', dataIndex: 'actualAmount', key: 'actualAmount' },
-    { title: 'Різниця', dataIndex: 'diff', key: 'diff' },
+    {
+      title: 'План %',
+      dataIndex: 'plannedPercent',
+      key: 'plannedPercent',
+      render: text => `${text}%`,
+    },
+    { title: 'Факт %', dataIndex: 'actualPercent', key: 'actualPercent', render: text => `${text}%` },
+    { title: 'Факт сума', dataIndex: 'actualAmount', key: 'actualAmount' },
   ];
+
+  const renderList = (group) => (
+    data
+      .filter(d => d.group === group)
+      .map(d => (
+        <li key={d.name}>
+          {d.name}: план {d.plannedPercent}% , факт {d.actualPercent}% ({d.actualAmount})
+        </li>
+      ))
+  );
 
   return (
     <div style={{ padding: 20 }}>
@@ -52,6 +77,28 @@ const BusinessModel = () => {
         pagination={false}
         bordered
       />
+      <h3 style={{ marginTop: 20 }}>Спрощена фінансова модель (P&L у %)</h3>
+      <ul>
+        <li>Виручка = 100% ({totalTurnover.toFixed(2)})</li>
+        <li>
+          Змінні витрати:
+          <ul>
+            {renderList('Змінні витрати')}
+          </ul>
+        </li>
+        <li>
+          Фіксовані витрати:
+          <ul>
+            {renderList('Фіксовані витрати')}
+          </ul>
+        </li>
+        <li>
+          Разом витрати: план 75-85%, факт {expensePercent.toFixed(2)}% ({totalExpenses.toFixed(2)})
+        </li>
+        <li>
+          Чистий прибуток: план 10-20%, факт {profitPercent.toFixed(2)}% ({profitAmount.toFixed(2)})
+        </li>
+      </ul>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add simplified financial model with planned percentage ranges
- compute actual percentages and amounts from transactions
- display revenue, expenses, and profit list

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a39628ffcc832e94b349c2024b93f7