### PR TITLE
Add food cost page using Poster API

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import Signup from './pages/Signup'
 import Dashboard from './pages/Dashboard'
 import Statistics from './pages/Statistics'
 import BusinessModel from './pages/BusinessModel'
+import FoodCosts from './pages/FoodCosts'
 import ProtectedRoute from './components/ProtectedRoute'
 import {ToastContainer} from 'react-toastify'
 import 'react-toastify/dist/ReactToastify.css'
@@ -50,6 +51,14 @@ function App() {
             element={
               <ProtectedRoute>
                 <BusinessModel />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path='/food-costs'
+            element={
+              <ProtectedRoute>
+                <FoodCosts />
               </ProtectedRoute>
             }
           />

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -8,6 +8,7 @@ import {
   AiOutlineBarChart,
   AiOutlineFundProjectionScreen,
   AiOutlineMenu,
+  AiOutlineUnorderedList,
 } from 'react-icons/ai'
 import UserProfile from '../UserProfileFeture'
 import {Link} from 'react-router-dom'
@@ -84,6 +85,11 @@ const Header = () => {
       to: '/business-model',
       icon: <AiOutlineFundProjectionScreen />,
       label: 'Фін-модель',
+    },
+    {
+      to: '/food-costs',
+      icon: <AiOutlineUnorderedList />,
+      label: 'Фудкост',
     },
   ]
 

--- a/src/pages/FoodCosts.js
+++ b/src/pages/FoodCosts.js
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import { Table } from 'antd';
+
+const API_TOKEN = '433607:80265139b087d9e83b4f4952f4d416cc';
+
+const FoodCosts = () => {
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const res = await fetch(`https://api.joinposter.com/menu.getMenu?token=${API_TOKEN}`);
+        const json = await res.json();
+        const items = json.response?.menu || json.response || [];
+        const products = Array.isArray(items)
+          ? items.flatMap((item) => item.products || item)
+          : [];
+        const tableData = products.map((prod) => ({
+          key: prod.product_id,
+          name: prod.product_name,
+          primeCost: prod.primeCost,
+        }));
+        setData(tableData);
+      } catch (e) {
+        console.error('Failed to fetch food costs', e);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, []);
+
+  const columns = [
+    { title: 'Назва', dataIndex: 'name', key: 'name' },
+    { title: 'Фудкост', dataIndex: 'primeCost', key: 'primeCost' },
+  ];
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h2>Фудкост страв</h2>
+      <Table columns={columns} dataSource={data} loading={loading} rowKey="key" />
+    </div>
+  );
+};
+
+export default FoodCosts;


### PR DESCRIPTION
## Summary
- create FoodCosts page that fetches dish prime costs from Poster API
- route and navigation updates for easy access

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68a39ab69330832ea1ca5a70fd49d7ef