### PR TITLE
feat: add settings page and finmodel support

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import Signup from './pages/Signup'
 import Dashboard from './pages/Dashboard'
 import Statistics from './pages/Statistics'
 import BusinessModel from './pages/BusinessModel'
+import Settings from './pages/Settings'
 import ProtectedRoute from './components/ProtectedRoute'
 import {ToastContainer} from 'react-toastify'
 import 'react-toastify/dist/ReactToastify.css'
@@ -50,6 +51,14 @@ function App() {
             element={
               <ProtectedRoute>
                 <BusinessModel />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path='/settings'
+            element={
+              <ProtectedRoute>
+                <Settings />
               </ProtectedRoute>
             }
           />

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -8,6 +8,7 @@ import {
   AiOutlineBarChart,
   AiOutlineFundProjectionScreen,
   AiOutlineMenu,
+  AiOutlineSetting,
 } from 'react-icons/ai'
 import UserProfile from '../UserProfileFeture'
 import {Link} from 'react-router-dom'
@@ -85,6 +86,7 @@ const Header = () => {
       icon: <AiOutlineFundProjectionScreen />,
       label: 'Фін-модель',
     },
+    { to: '/settings', icon: <AiOutlineSetting />, label: 'Налаштування' },
   ]
 
   if (!user) return null

--- a/src/components/HeaderWithAddButton.js
+++ b/src/components/HeaderWithAddButton.js
@@ -51,6 +51,7 @@ const HeaderWithAddButton = () => {
       name: values.name,
       comments: values.comments || '',
       account: values.account,
+      finmodel: values.finmodel,
     });
 
     handleExpenseCancel();

--- a/src/components/TransactionsTable/index.js
+++ b/src/components/TransactionsTable/index.js
@@ -73,6 +73,7 @@ const TransactionsTable = ({ transactions, deleteTransaction, editTransaction })
       },
     },
     { title: 'Назва', dataIndex: 'name', key: 'name' },
+    { title: 'Finmodel', dataIndex: 'finmodel', key: 'finmodel', render: (v) => v || '—' },
     { title: 'Коментарі', dataIndex: 'comments', key: 'comments' },
     {
       title: 'Дії',

--- a/src/components/forms/AccountSelect.jsx
+++ b/src/components/forms/AccountSelect.jsx
@@ -1,56 +1,16 @@
-import React, { useState } from 'react'
-import { Select, Input, Button, message } from 'antd'
-import { useAccounts } from '../../context/AccountsContext'
+import { Select } from 'antd';
+import { useAccounts } from '../../context/AccountsContext';
 
-const { Option } = Select
+const { Option } = Select;
 
 const AccountSelect = ({ value, onChange }) => {
-  const { accounts, addAccount } = useAccounts()
-  const [newAccount, setNewAccount] = useState('')
-  const [adding, setAdding] = useState(false)
-
-  const onAddAccount = async () => {
-    const trimmed = newAccount.trim()
-    if (!trimmed) {
-      message.error('Введіть назву рахунку')
-      return
-    }
-    setAdding(true)
-    try {
-      await addAccount({ name: trimmed })
-      onChange(trimmed) // Автоматично обираємо новий рахунок
-      setNewAccount('')
-      message.success('Рахунок додано')
-    } catch {
-      message.error('Помилка додавання рахунку')
-    } finally {
-      setAdding(false)
-    }
-  }
-
+  const { accounts } = useAccounts();
   return (
     <Select
       showSearch
-      placeholder='Оберіть або додайте рахунок'
+      placeholder='Оберіть рахунок'
       value={value}
       onChange={onChange}
-      dropdownRender={(menu) => (
-        <>
-          {menu}
-          <div style={{ display: 'flex', padding: 8 }}>
-            <Input
-              style={{ flex: 'auto' }}
-              value={newAccount}
-              onChange={(e) => setNewAccount(e.target.value)}
-              onPressEnter={onAddAccount}
-              placeholder='Новий рахунок'
-            />
-            <Button type='link' loading={adding} onClick={onAddAccount}>
-              Додати
-            </Button>
-          </div>
-        </>
-      )}
       filterOption={(input, option) =>
         option?.children?.toString().toLowerCase().includes(input.toLowerCase())
       }
@@ -61,7 +21,8 @@ const AccountSelect = ({ value, onChange }) => {
         </Option>
       ))}
     </Select>
-  )
-}
+  );
+};
 
-export default AccountSelect
+export default AccountSelect;
+

--- a/src/components/forms/AddExpense.jsx
+++ b/src/components/forms/AddExpense.jsx
@@ -2,6 +2,7 @@ import {Button, Modal, Form, Input, DatePicker} from 'antd'
 import {useState, useEffect} from 'react'
 import AccountSelect from './AccountSelect'
 import ExpenseCategorySelect from './ExpenseCategorySelect'
+import FinModelSelect from './FinModelSelect'
 import dayjs from 'dayjs'
 
 const toDayjs = (value) => {
@@ -24,6 +25,7 @@ const AddExpense = ({
       form.setFieldsValue({
         amount: initialValues.amount,
         account: initialValues.account,
+        finmodel: initialValues.finmodel,
         date: toDayjs(initialValues.date),
         comments: initialValues.comments,
       })
@@ -71,6 +73,15 @@ const AddExpense = ({
           rules={[{required: true, message: 'Please enter the expense amount'}]}
         >
           <Input type='number' inputMode='decimal' addonBefore='₴' />
+        </Form.Item>
+
+        <Form.Item
+          style={{fontWeight: 600}}
+          label='Finmodel'
+          name='finmodel'
+          rules={[{required: true, message: 'Оберіть фінмодель'}]}
+        >
+          <FinModelSelect />
         </Form.Item>
 
         <Form.Item

--- a/src/components/forms/AddIncome.jsx
+++ b/src/components/forms/AddIncome.jsx
@@ -1,5 +1,6 @@
 import {Button, Modal, Form, Input, DatePicker} from 'antd'
 import AccountSelect from './AccountSelect'
+import FinModelSelect from './FinModelSelect'
 import dayjs from 'dayjs'
 import {useEffect} from 'react'
 
@@ -22,6 +23,7 @@ const AddIncome = ({
         amount: initialValues.amount,
         account: initialValues.account,
         name: initialValues.name,
+        finmodel: initialValues.finmodel,
         date: toDayjs(initialValues.date),
         comments: initialValues.comments,
       })
@@ -59,6 +61,15 @@ const AddIncome = ({
             ]}
           >
             <Input type='number' inputMode='decimal' addonBefore='₴' />
+          </Form.Item>
+
+          <Form.Item
+            style={{fontWeight: 600}}
+            label='Finmodel'
+            name='finmodel'
+            rules={[{required: true, message: 'Оберіть фінмодель'}]}
+          >
+            <FinModelSelect />
           </Form.Item>
 
           <Form.Item

--- a/src/components/forms/FinModelSelect.jsx
+++ b/src/components/forms/FinModelSelect.jsx
@@ -1,0 +1,28 @@
+import { Select } from 'antd';
+import { useFinModels } from '../../context/FinModelsContext';
+
+const { Option } = Select;
+
+const FinModelSelect = ({ value, onChange }) => {
+  const { finmodels } = useFinModels();
+  return (
+    <Select
+      showSearch
+      placeholder='Оберіть фінмодель'
+      value={value}
+      onChange={onChange}
+      filterOption={(input, option) =>
+        option?.children?.toString().toLowerCase().includes(input.toLowerCase())
+      }
+    >
+      {finmodels.map((fm) => (
+        <Option key={fm.id} value={fm.name}>
+          {fm.name}
+        </Option>
+      ))}
+    </Select>
+  );
+};
+
+export default FinModelSelect;
+

--- a/src/context/AccountsContext.js
+++ b/src/context/AccountsContext.js
@@ -1,29 +1,32 @@
-import {createContext, useContext, useEffect, useRef, useState} from 'react'
-import {auth, db} from '../firebase'
-import {useAuthState} from 'react-firebase-hooks/auth'
+import { createContext, useContext, useEffect, useRef, useState } from 'react';
+import { auth, db } from '../firebase';
+import { useAuthState } from 'react-firebase-hooks/auth';
 import {
   collection,
   addDoc,
+  updateDoc,
+  deleteDoc,
+  doc,
   onSnapshot,
   orderBy,
   query,
   serverTimestamp,
-} from 'firebase/firestore'
-import {toast} from 'react-toastify'
+} from 'firebase/firestore';
+import { toast } from 'react-toastify';
 
-const AccountsContext = createContext(null)
-export const useAccounts = () => useContext(AccountsContext)
+const AccountsContext = createContext(null);
+export const useAccounts = () => useContext(AccountsContext);
 
-export const AccountsProvider = ({children}) => {
-  const [user] = useAuthState(auth)
-  const [accounts, setAccounts] = useState([])
-  const unsubRef = useRef(null)
+export const AccountsProvider = ({ children }) => {
+  const [user] = useAuthState(auth);
+  const [accounts, setAccounts] = useState([]);
+  const unsubRef = useRef(null);
 
-  const accountsRef = collection(db, 'workspaces', 'mainWorkspace', 'accounts')
+  const accountsRef = collection(db, 'workspaces', 'mainWorkspace', 'accounts');
 
-  const addAccount = async ({name, type = 'card', currency = 'UAH'}) => {
-    if (!user) return
-    if (!name?.trim()) return toast.error('Вкажіть назву рахунку')
+  const addAccount = async ({ name, type = 'card', currency = 'UAH' }) => {
+    if (!user) return;
+    if (!name?.trim()) return toast.error('Вкажіть назву рахунку');
     try {
       await addDoc(accountsRef, {
         name: name.trim(),
@@ -32,36 +35,60 @@ export const AccountsProvider = ({children}) => {
         order: accounts.length,
         createdBy: user.uid,
         createdAt: serverTimestamp(),
-      })
-      toast.success('Рахунок додано')
+      });
+      toast.success('Рахунок додано');
     } catch (e) {
-      console.error(e)
-      toast.error('Не вдалося додати рахунок')
+      console.error(e);
+      toast.error('Не вдалося додати рахунок');
     }
-  }
+  };
+
+  const updateAccount = async (id, updates) => {
+    if (!user) return;
+    try {
+      const ref = doc(db, 'workspaces', 'mainWorkspace', 'accounts', id);
+      await updateDoc(ref, { ...updates, updatedAt: serverTimestamp() });
+      toast.success('Рахунок оновлено');
+    } catch (e) {
+      console.error(e);
+      toast.error('Не вдалося оновити рахунок');
+    }
+  };
+
+  const deleteAccount = async (id) => {
+    if (!user) return;
+    try {
+      await deleteDoc(doc(db, 'workspaces', 'mainWorkspace', 'accounts', id));
+      toast.success('Рахунок видалено');
+    } catch (e) {
+      console.error(e);
+      toast.error('Не вдалося видалити рахунок');
+    }
+  };
 
   useEffect(() => {
     if (!user) {
-      setAccounts([])
-      return
+      setAccounts([]);
+      return;
     }
-    const q = query(accountsRef, orderBy('order', 'asc'))
+    const q = query(accountsRef, orderBy('order', 'asc'));
     unsubRef.current = onSnapshot(
       q,
       (snap) => {
-        setAccounts(snap.docs.map((d) => ({id: d.id, ...d.data()})))
+        setAccounts(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
       },
       (err) => {
-        console.error('accounts onSnapshot:', err)
+        console.error('accounts onSnapshot:', err);
       }
-    )
-    return () => unsubRef.current?.()
+    );
+    return () => unsubRef.current?.();
     // eslint-disable-next-line
-  }, [user?.uid])
+  }, [user?.uid]);
 
   return (
-    <AccountsContext.Provider value={{accounts, addAccount}}>
+    <AccountsContext.Provider value={{ accounts, addAccount, updateAccount, deleteAccount }}>
       {children}
     </AccountsContext.Provider>
-  )
-}
+  );
+};
+

--- a/src/context/FinModelsContext.js
+++ b/src/context/FinModelsContext.js
@@ -1,0 +1,92 @@
+import { createContext, useContext, useEffect, useRef, useState } from 'react';
+import { auth, db } from '../firebase';
+import { useAuthState } from 'react-firebase-hooks/auth';
+import {
+  collection,
+  addDoc,
+  updateDoc,
+  deleteDoc,
+  doc,
+  onSnapshot,
+  orderBy,
+  query,
+  serverTimestamp,
+} from 'firebase/firestore';
+import { toast } from 'react-toastify';
+
+const FinModelsContext = createContext(null);
+export const useFinModels = () => useContext(FinModelsContext);
+
+export const FinModelsProvider = ({ children }) => {
+  const [user] = useAuthState(auth);
+  const [finmodels, setFinmodels] = useState([]);
+  const unsubRef = useRef(null);
+
+  const finmodelsRef = collection(db, 'workspaces', 'mainWorkspace', 'finmodels');
+
+  const addFinModel = async ({ name }) => {
+    if (!user) return;
+    if (!name?.trim()) return toast.error('Вкажіть назву фінмоделі');
+    try {
+      await addDoc(finmodelsRef, {
+        name: name.trim(),
+        order: finmodels.length,
+        createdBy: user.uid,
+        createdAt: serverTimestamp(),
+      });
+      toast.success('Фінмодель додано');
+    } catch (e) {
+      console.error(e);
+      toast.error('Не вдалося додати фінмодель');
+    }
+  };
+
+  const updateFinModel = async (id, updates) => {
+    if (!user) return;
+    try {
+      const ref = doc(db, 'workspaces', 'mainWorkspace', 'finmodels', id);
+      await updateDoc(ref, { ...updates, updatedAt: serverTimestamp() });
+      toast.success('Фінмодель оновлено');
+    } catch (e) {
+      console.error(e);
+      toast.error('Не вдалося оновити фінмодель');
+    }
+  };
+
+  const deleteFinModel = async (id) => {
+    if (!user) return;
+    try {
+      await deleteDoc(doc(db, 'workspaces', 'mainWorkspace', 'finmodels', id));
+      toast.success('Фінмодель видалено');
+    } catch (e) {
+      console.error(e);
+      toast.error('Не вдалося видалити фінмодель');
+    }
+  };
+
+  useEffect(() => {
+    if (!user) {
+      setFinmodels([]);
+      return;
+    }
+    const q = query(finmodelsRef, orderBy('order', 'asc'));
+    unsubRef.current = onSnapshot(
+      q,
+      (snap) => {
+        setFinmodels(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
+      },
+      (err) => {
+        console.error('finmodels onSnapshot:', err);
+      }
+    );
+    return () => unsubRef.current?.();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user?.uid]);
+
+  return (
+    <FinModelsContext.Provider value={{ finmodels, addFinModel, updateFinModel, deleteFinModel }}>
+      {children}
+    </FinModelsContext.Provider>
+  );
+};
+

--- a/src/context/TransactionsContext.js
+++ b/src/context/TransactionsContext.js
@@ -76,6 +76,7 @@ export const TransactionsProvider = ({ children }) => {
           date: t.date,
           comments: t.comments ?? '',
           name: t.name ?? '',
+          finmodel: t.finmodel ?? '',
         });
       }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import {TransactionsProvider} from './context/TransactionsContext'
 import {ExpenseCategoriesProvider} from './context/ExpenseCategoriesContext'
 import {DateRangeProvider} from './context/DateRangeContext'
 import {AccountsProvider} from './context/AccountsContext'
+import {FinModelsProvider} from './context/FinModelsContext'
 import './index.css'
 import {register} from './serviceWorkerRegistration'
 
@@ -16,7 +17,9 @@ ReactDOM.render(
       <TransactionsProvider>
         <DateRangeProvider>
           <AccountsProvider>
-            <App />
+            <FinModelsProvider>
+              <App />
+            </FinModelsProvider>
           </AccountsProvider>
         </DateRangeProvider>
       </TransactionsProvider>

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -73,6 +73,7 @@ const Dashboard = () => {
       name: values.name,
       comments: values.comments || '',
       account: values.account,
+      finmodel: values.finmodel,
     })
     setEditing(null)
   }

--- a/src/pages/Settings.js
+++ b/src/pages/Settings.js
@@ -1,0 +1,103 @@
+import { useState } from 'react';
+import { Table, Button, Form, Input, Modal, Popconfirm } from 'antd';
+import { useAccounts } from '../context/AccountsContext';
+import { useFinModels } from '../context/FinModelsContext';
+
+const Settings = () => {
+  const { accounts, addAccount, updateAccount, deleteAccount } = useAccounts();
+  const { finmodels, addFinModel, updateFinModel, deleteFinModel } = useFinModels();
+
+  const [accForm] = Form.useForm();
+  const [fmForm] = Form.useForm();
+  const [accEditForm] = Form.useForm();
+  const [fmEditForm] = Form.useForm();
+  const [editingAcc, setEditingAcc] = useState(null);
+  const [editingFm, setEditingFm] = useState(null);
+
+  const accColumns = [
+    { title: 'Назва', dataIndex: 'name', key: 'name' },
+    {
+      title: 'Дії',
+      key: 'actions',
+      render: (_, record) => (
+        <>
+          <Button type='link' onClick={() => { setEditingAcc(record); accEditForm.setFieldsValue({ name: record.name }); }}>Редагувати</Button>
+          <Popconfirm title='Видалити?' okText='Так' cancelText='Ні' onConfirm={() => deleteAccount(record.id)}>
+            <Button type='link' danger>Видалити</Button>
+          </Popconfirm>
+        </>
+      ),
+    },
+  ];
+
+  const fmColumns = [
+    { title: 'Назва', dataIndex: 'name', key: 'name' },
+    {
+      title: 'Дії',
+      key: 'actions',
+      render: (_, record) => (
+        <>
+          <Button type='link' onClick={() => { setEditingFm(record); fmEditForm.setFieldsValue({ name: record.name }); }}>Редагувати</Button>
+          <Popconfirm title='Видалити?' okText='Так' cancelText='Ні' onConfirm={() => deleteFinModel(record.id)}>
+            <Button type='link' danger>Видалити</Button>
+          </Popconfirm>
+        </>
+      ),
+    },
+  ];
+
+  return (
+    <div className='container' style={{ padding: 20 }}>
+      <h2>Рахунки</h2>
+      <Form form={accForm} layout='inline' onFinish={async ({ name }) => { await addAccount({ name }); accForm.resetFields(); }}>
+        <Form.Item name='name' rules={[{ required: true, message: 'Введіть назву рахунку' }]}>
+          <Input placeholder='Новий рахунок' />
+        </Form.Item>
+        <Form.Item>
+          <Button type='primary' htmlType='submit'>Додати</Button>
+        </Form.Item>
+      </Form>
+      <Table dataSource={accounts} columns={accColumns} rowKey='id' pagination={false} style={{ marginTop: 16 }} />
+
+      <h2 style={{ marginTop: 32 }}>Finmodel</h2>
+      <Form form={fmForm} layout='inline' onFinish={async ({ name }) => { await addFinModel({ name }); fmForm.resetFields(); }}>
+        <Form.Item name='name' rules={[{ required: true, message: 'Введіть назву фінмоделі' }]}>
+          <Input placeholder='Нова фінмодель' />
+        </Form.Item>
+        <Form.Item>
+          <Button type='primary' htmlType='submit'>Додати</Button>
+        </Form.Item>
+      </Form>
+      <Table dataSource={finmodels} columns={fmColumns} rowKey='id' pagination={false} style={{ marginTop: 16 }} />
+
+      <Modal
+        title='Редагувати рахунок'
+        open={!!editingAcc}
+        onCancel={() => setEditingAcc(null)}
+        onOk={() => accEditForm.submit()}
+      >
+        <Form form={accEditForm} onFinish={async ({ name }) => { await updateAccount(editingAcc.id, { name }); setEditingAcc(null); }}>
+          <Form.Item name='name' rules={[{ required: true, message: 'Введіть назву рахунку' }]}>
+            <Input />
+          </Form.Item>
+        </Form>
+      </Modal>
+
+      <Modal
+        title='Редагувати фінмодель'
+        open={!!editingFm}
+        onCancel={() => setEditingFm(null)}
+        onOk={() => fmEditForm.submit()}
+      >
+        <Form form={fmEditForm} onFinish={async ({ name }) => { await updateFinModel(editingFm.id, { name }); setEditingFm(null); }}>
+          <Form.Item name='name' rules={[{ required: true, message: 'Введіть назву фінмоделі' }]}>
+            <Input />
+          </Form.Item>
+        </Form>
+      </Modal>
+    </div>
+  );
+};
+
+export default Settings;
+


### PR DESCRIPTION
## Summary
- add settings page to manage accounts and finmodels
- track finmodel for income and expense transactions
- show finmodel column in transaction table and remove inline account creation

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d3b5aa94832eb97381892753f8ec