### PR TITLE
Show transfer entries as separate rows

### DIFF
--- a/src/components/TransactionsTable/index.js
+++ b/src/components/TransactionsTable/index.js
@@ -46,10 +46,7 @@ const TransactionsTable = ({ transactions, deleteTransaction, editTransaction })
     {
       title: 'Рахунок',
       key: 'account',
-      render: (_, record) =>
-        record.type === 'transfer'
-          ? `${record.from} → ${record.to}`
-          : record.account || '—',
+      render: (_, record) => record.account || '—',
     },
     {
       title: 'Тип',
@@ -79,11 +76,6 @@ const TransactionsTable = ({ transactions, deleteTransaction, editTransaction })
       title: 'Дії',
       key: 'actions',
       render: (_, record) => {
-        const docIdForDelete =
-          record.type === 'transfer'
-            ? (record._pairDocIds?.[0] || record.id)
-            : record.id
-
         const items = []
 
         items.push({
@@ -100,7 +92,7 @@ const TransactionsTable = ({ transactions, deleteTransaction, editTransaction })
               title="Видалити?"
               okText="Так"
               cancelText="Ні"
-              onConfirm={() => deleteTransaction?.(docIdForDelete)}
+              onConfirm={() => deleteTransaction?.(record.id)}
               onClick={(e) => e.stopPropagation()}
             >
               Видалити
@@ -128,9 +120,9 @@ const TransactionsTable = ({ transactions, deleteTransaction, editTransaction })
           rowKey="id"
           className='table'
           rowClassName={(record) => {
+            if (record.isTransfer) return 'row-transfer'
             if (record.type === 'income') return 'row-income'
             if (record.type === 'expense') return 'row-expense'
-            if (record.type === 'transfer') return 'row-transfer'
             if (record.type === 'dividend') return 'row-dividend'
             if (record.type === 'investment') return 'row-investment'
             return ''

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -91,7 +91,10 @@ const Dashboard = () => {
 
   const data = useMemo(() => {
     const base = (tableRows?.length ? tableRows : transactions) || []
-    const byType = base.filter((t) => types.includes(t.type))
+    const byType = base.filter((t) => {
+      const key = t.isTransfer ? 'transfer' : t.type
+      return types.includes(key)
+    })
     if (!hasRange) return byType
 
     const startTs = startDate.getTime()
@@ -134,7 +137,7 @@ const Dashboard = () => {
         deleteTransaction={deleteTransaction}
         editTransaction={startEdit}
       />
-      {editing?.type === 'income' && (
+      {editing?.type === 'income' && !editing?.isTransfer && (
         <AddIncome
           isIncomeModalVisible
           handleIncomeCancel={cancelEdit}
@@ -142,7 +145,7 @@ const Dashboard = () => {
           initialValues={editing}
         />
       )}
-      {editing?.type === 'expense' && (
+      {editing?.type === 'expense' && !editing?.isTransfer && (
         <AddExpense
           isExpenseModalVisible
           handleExpenseCancel={cancelEdit}
@@ -166,7 +169,7 @@ const Dashboard = () => {
           initialValues={editing}
         />
       )}
-      {editing?.type === 'transfer' && (
+      {editing?.isTransfer && (
         <AddTransfer
           isTransferModalVisible
           handleTransferCancel={cancelEdit}


### PR DESCRIPTION
## Summary
- Stop grouping paired transfer documents into a single row and retain all transfer metadata for each entry
- Filter and edit transfers using the `isTransfer` flag
- Render account directly and style transfer rows individually

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found, exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a63cf45afc832eb1c6005084dc66b5