### PR TITLE
Refactor date normalization and memoize transactions table

### DIFF
--- a/src/components/HeaderWithAddButton.js
+++ b/src/components/HeaderWithAddButton.js
@@ -8,13 +8,7 @@ import AddExpense from './forms/AddExpense';
 import AddTransfer from './forms/AddTransfer';
 import AddDividend from './forms/AddDividend';
 import AddInvestment from './forms/AddInvestment';
-
-const normalizeToDate = (v) => {
-  if (!v) return null;
-  if (typeof v?.toDate === 'function') return v.toDate(); // dayjs/antd
-  if (v instanceof Date) return v;
-  return new Date(v);
-};
+import { normalizeToDate } from '../utils/date';
 
 const HeaderWithAddButton = () => {
   const { addTransaction, addTransfer } = useTransactions();

--- a/src/components/TransactionsTable/index.js
+++ b/src/components/TransactionsTable/index.js
@@ -1,3 +1,4 @@
+import { useMemo, useCallback } from 'react'
 import './styles.css'
 import { Table, Popconfirm, Dropdown, Button } from 'antd'
 import {
@@ -11,16 +12,10 @@ import {
   StockOutlined,
 } from '@ant-design/icons'
 import dayjs from 'dayjs'
-
-const normalizeToDate = (value) => {
-  if (!value) return null
-  if (typeof value?.toDate === 'function') return value.toDate()
-  if (value instanceof Date) return value
-  return new Date(value)
-}
+import { normalizeToDate } from '../../utils/date'
 
 const TransactionsTable = ({ transactions, deleteTransaction, editTransaction }) => {
-  const columns = [
+  const columns = useMemo(() => [
     {
       title: 'Дата',
       dataIndex: 'date',
@@ -29,18 +24,14 @@ const TransactionsTable = ({ transactions, deleteTransaction, editTransaction })
         const d = normalizeToDate(value)
         return d ? dayjs(d).format('DD.MM.YY') : ''
       },
-      // sorter: (a, b) => {
-      //   const da = normalizeToDate(a.date)?.getTime() ?? 0
-      //   const db = normalizeToDate(b.date)?.getTime() ?? 0
-      //   return da - db
-      // },
       defaultSortOrder: 'descend',
     },
     {
       title: 'Сума',
       dataIndex: 'amount',
       key: 'amount',
-      render: (v) => Number(v).toLocaleString('uk-UA', { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
+      render: (v) =>
+        Number(v).toLocaleString('uk-UA', { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
       sorter: (a, b) => Number(a.amount) - Number(b.amount),
     },
     {
@@ -108,7 +99,16 @@ const TransactionsTable = ({ transactions, deleteTransaction, editTransaction })
         )
       },
     },
-  ]
+  ], [deleteTransaction, editTransaction])
+
+  const rowClassName = useCallback((record) => {
+    if (record.isTransfer) return 'row-transfer'
+    if (record.type === 'income') return 'row-income'
+    if (record.type === 'expense') return 'row-expense'
+    if (record.type === 'dividend') return 'row-dividend'
+    if (record.type === 'investment') return 'row-investment'
+    return ''
+  }, [])
 
   return (
     <div className='table-box container'>
@@ -119,14 +119,7 @@ const TransactionsTable = ({ transactions, deleteTransaction, editTransaction })
           columns={columns}
           rowKey="id"
           className='table'
-          rowClassName={(record) => {
-            if (record.isTransfer) return 'row-transfer'
-            if (record.type === 'income') return 'row-income'
-            if (record.type === 'expense') return 'row-expense'
-            if (record.type === 'dividend') return 'row-dividend'
-            if (record.type === 'investment') return 'row-investment'
-            return ''
-          }}
+          rowClassName={rowClassName}
         />
       </div>
     </div>

--- a/src/context/TransactionsContext.js
+++ b/src/context/TransactionsContext.js
@@ -7,17 +7,10 @@ import {
   writeBatch,
 } from "firebase/firestore";
 import { toast } from "react-toastify";
+import { normalizeToDate } from "../utils/date";
 
 const TransactionsContext = createContext();
 export const useTransactions = () => useContext(TransactionsContext);
-
-// ✅ уніфікація дат
-const normalizeToDate = (value) => {
-  if (!value) return null;
-  if (typeof value?.toDate === 'function') return value.toDate(); // Firestore.Timestamp
-  if (value instanceof Date) return value;
-  return new Date(value); // string/number/dayjs -> Date
-};
 
 export const TransactionsProvider = ({ children }) => {
   const [user] = useAuthState(auth);

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -8,6 +8,7 @@ import AddDividend from '../components/forms/AddDividend'
 import AddInvestment from '../components/forms/AddInvestment'
 import { useTransactions } from '../context/TransactionsContext'
 import { useDateRange } from '../context/DateRangeContext'
+import { normalizeToDate } from '../utils/date'
 
 const { RangePicker } = DatePicker
 
@@ -18,13 +19,6 @@ const TYPE_OPTIONS = [
   { label: 'Дивіденди', value: 'dividend' },
   { label: 'Інвестиції', value: 'investment' },
 ]
-
-const normalizeToDate = (v) => {
-  if (!v) return null
-  if (typeof v?.toDate === 'function') return v.toDate()
-  if (v instanceof Date) return v
-  return new Date(v)
-}
 
 const Dashboard = () => {
   const {

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -1,0 +1,6 @@
+export const normalizeToDate = (value) => {
+  if (!value) return null
+  if (typeof value?.toDate === 'function') return value.toDate()
+  if (value instanceof Date) return value
+  return new Date(value)
+}


### PR DESCRIPTION
## Summary
- extract a shared `normalizeToDate` utility and reuse it across the dashboard, header actions, and transactions context
- memoize the transactions table column configuration and row className callback to avoid unnecessary recalculations on re-render

## Testing
- npm run test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68d1a4cc7960832eb014c68d3a7f8ba9