### PR TITLE
Fix CI build failure without test suites

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --watchAll=false --passWithNoTests",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {


### PR DESCRIPTION
## Summary
- update the npm test script to use --watchAll=false and --passWithNoTests so CI no longer fails when no suites are present

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5b940bb64832ebd5fa3b51d8d04ef